### PR TITLE
Add GitHub Actions workflow

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,6 +1,6 @@
 name: Python Package using Conda
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build-linux:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,50 @@
+name: Python Package using Conda
+
+on: [push]
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-20.04
+    strategy:
+      max-parallel: 5
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.6.15
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.6.15'
+    - name: Create conda/mamba environment using micromamba
+      uses: mamba-org/setup-micromamba@v1
+      with:
+        environment-file: environment.yml
+        cache-downloads: true
+    - name: Add micromamba to system path                                                                                                                                                                                                                         
+      run: |                                                                                                                                                                                                                                                 
+        # $CONDA is an environment variable pointing to the root of the miniconda directory                                                                                                                                                                  
+        echo $CONDA/bin >> $GITHUB_PATH
+    - name: Set EMU_DATABASE env variable
+      run: echo "EMU_DATABASE_DIR=./emu_database" >> $GITHUB_ENV
+    - name: Lint with flake8
+      run: |
+        micromamba install flake8
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        micromamba install pytest
+        pytest
+    - name: "Run example: full length"
+      run: |
+        python emu abundance example/full_length.fa
+    - name: "Run example: short-read fwd+rev"
+      run: |
+        python emu abundance --type sr example/short_read_f.fq example/short_read_r.fq
+    - name: "Run example: short-read fwd only"
+      run:
+        python emu abundance --type sr example/short_read_f.fq

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -39,12 +39,3 @@ jobs:
       run: |
         micromamba install pytest
         pytest
-    - name: "Run example: full length"
-      run: |
-        python emu abundance example/full_length.fa
-    - name: "Run example: short-read fwd+rev"
-      run: |
-        python emu abundance --type sr example/short_read_f.fq example/short_read_r.fq
-    - name: "Run example: short-read fwd only"
-      run:
-        python emu abundance --type sr example/short_read_f.fq

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ## Emu: species-level taxonomic abundance for full-length 16S reads
 
+[![Tests](https://github.com/treangenlab/emu/actions/workflows/python-tests.yml/badge.svg)](https://github.com/treangenlab/emu/actions/workflows/python-tests.yml)
 
 ### Description
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,9 @@
 name: custom-emu
 
 channels:
-  - bioconda
   - conda-forge
+  - bioconda
+  - nodefaults
 
 dependencies:
   - biopython

--- a/tests/test_emu.py
+++ b/tests/test_emu.py
@@ -1,0 +1,6 @@
+def test_placeholder():
+    """
+    Add an empty test so as not to fail the pytest process until some real
+    tests have been added.
+    """
+    assert True

--- a/tests/test_emu_cli.py
+++ b/tests/test_emu_cli.py
@@ -1,0 +1,48 @@
+import pytest
+import subprocess
+import os
+import pandas as pd
+
+
+@pytest.mark.parametrize(
+    "emu_command, abundance_file, expected_abundancies",
+    [
+        (
+            "./emu abundance --db emu_database --output-dir test_results example/full_length.fa",
+            "test_results/full_length_rel-abundance.tsv",
+            {
+                "Sphingobacterium puteale": 0.5,
+                "Mycobacterium saskatchewanense": 0.25,
+                "Streptococcus sobrinus": 0.25,
+            },
+        ),
+        (
+            "./emu abundance --db emu_database --output-dir test_results --type sr example/short_read_f.fq",
+            "test_results/short_read_f_rel-abundance.tsv",
+            {
+                "Staphylococcus hominis": 1.0,
+            },
+        ),
+        (
+            "./emu abundance --db emu_database --output-dir test_results --type sr example/short_read_f.fq example/short_read_r.fq",
+            "test_results/short_read_f-short_read_r_rel-abundance.tsv",
+            {
+                "Staphylococcus aureus": 1.0 / 3,
+                "Salmonella enterica": 1.0 / 3,
+                "Enterococcus columbae": 1.0 / 3,
+            },
+        ),
+    ],
+)
+def test_cli_on_example_datasets(emu_command, abundance_file, expected_abundancies):
+    if os.path.exists(abundance_file):
+        os.remove(abundance_file)
+
+    subprocess.check_output(emu_command, shell=True)
+
+    assert os.path.exists(abundance_file)
+
+    df = abundance_df = pd.read_csv(abundance_file, sep="\t")
+
+    for species, expected_abundance in expected_abundancies.items():
+        assert df[df["species"] == species].iloc[0]["abundance"] == expected_abundance

--- a/tests/test_emu_cli.py
+++ b/tests/test_emu_cli.py
@@ -2,14 +2,15 @@ import pytest
 import subprocess
 import os
 import pandas as pd
+import tempfile
 
 
 @pytest.mark.parametrize(
-    "emu_command, abundance_file, expected_abundancies",
+    "emu_command_tpl, abundance_filepath_tpl, expected_abundancies",
     [
         (
-            "./emu abundance --db emu_database --output-dir test_results --keep-files example/full_length.fa",
-            "test_results/full_length_rel-abundance.tsv",
+            "./emu abundance --db emu_database --output-dir {tempdir_path} --keep-files example/full_length.fa",
+            "{tempdir_path}/full_length_rel-abundance.tsv",
             {
                 "Sphingobacterium puteale": 0.5,
                 "Mycobacterium saskatchewanense": 0.25,
@@ -17,15 +18,15 @@ import pandas as pd
             },
         ),
         (
-            "./emu abundance --db emu_database --output-dir test_results --type sr --keep-files example/short_read_f.fq",
-            "test_results/short_read_f_rel-abundance.tsv",
+            "./emu abundance --db emu_database --output-dir {tempdir_path} --type sr --keep-files example/short_read_f.fq",
+            "{tempdir_path}/short_read_f_rel-abundance.tsv",
             {
                 "Staphylococcus hominis": 1.0,
             },
         ),
         (
-            "./emu abundance --db emu_database --output-dir test_results --type sr --keep-files example/short_read_f.fq example/short_read_r.fq",
-            "test_results/short_read_f-short_read_r_rel-abundance.tsv",
+            "./emu abundance --db emu_database --output-dir {tempdir_path} --type sr --keep-files example/short_read_f.fq example/short_read_r.fq",
+            "{tempdir_path}/short_read_f-short_read_r_rel-abundance.tsv",
             {
                 "Staphylococcus aureus": 1.0 / 3,
                 "Salmonella enterica": 1.0 / 3,
@@ -34,15 +35,20 @@ import pandas as pd
         ),
     ],
 )
-def test_cli_on_example_datasets(emu_command, abundance_file, expected_abundancies):
-    if os.path.exists(abundance_file):
-        os.remove(abundance_file)
+def test_cli_on_example_datasets(emu_command_tpl, abundance_filepath_tpl, expected_abundancies):
+    tempdir = tempfile.TemporaryDirectory()
+
+    emu_command = emu_command_tpl.format(tempdir_path=tempdir.name)
+    abundance_filepath = abundance_filepath_tpl.format(tempdir_path=tempdir.name)
+
+    if os.path.exists(abundance_filepath):
+        os.remove(abundance_filepath)
 
     subprocess.check_output(emu_command, shell=True)
 
-    assert os.path.exists(abundance_file)
+    assert os.path.exists(abundance_filepath)
 
-    df = abundance_df = pd.read_csv(abundance_file, sep="\t")
+    df = abundance_df = pd.read_csv(abundance_filepath, sep="\t")
 
     for species, expected_abundance in expected_abundancies.items():
         assert df[df["species"] == species].iloc[0]["abundance"] == expected_abundance

--- a/tests/test_emu_cli.py
+++ b/tests/test_emu_cli.py
@@ -8,7 +8,7 @@ import pandas as pd
     "emu_command, abundance_file, expected_abundancies",
     [
         (
-            "./emu abundance --db emu_database --output-dir test_results example/full_length.fa",
+            "./emu abundance --db emu_database --output-dir test_results --keep-files example/full_length.fa",
             "test_results/full_length_rel-abundance.tsv",
             {
                 "Sphingobacterium puteale": 0.5,
@@ -17,14 +17,14 @@ import pandas as pd
             },
         ),
         (
-            "./emu abundance --db emu_database --output-dir test_results --type sr example/short_read_f.fq",
+            "./emu abundance --db emu_database --output-dir test_results --type sr --keep-files example/short_read_f.fq",
             "test_results/short_read_f_rel-abundance.tsv",
             {
                 "Staphylococcus hominis": 1.0,
             },
         ),
         (
-            "./emu abundance --db emu_database --output-dir test_results --type sr example/short_read_f.fq example/short_read_r.fq",
+            "./emu abundance --db emu_database --output-dir test_results --type sr --keep-files example/short_read_f.fq example/short_read_r.fq",
             "test_results/short_read_f-short_read_r_rel-abundance.tsv",
             {
                 "Staphylococcus aureus": 1.0 / 3,


### PR DESCRIPTION
As a first attempt at addressing #39 , this PR adds a somewhat minimal GitHub Actions workflow that:

- Runs a basic flake8 lint (warns mostly, only fails on critical issues)
- Runs pytest which right now just contains of a test placeholder (to keep the PR small)
- ~Runs the example workflows previously defined in `.gitlab-ci.yml`~
- **[Edit 2024-12-20]:** Run the example workflows previously defined in `.gitlab-ci.yml` via pytest, and checking that their generated abundancies are as expected.

It also adds a badge for the status of the tests, in README.md.

Worth noting:

- The workflow uses Python 3.6.15, as 3.6 is specified as the lowest requirement in `environment.yml`, and since this is a bit of an old version, it requires the slightly older ubuntu-20.04 image. This could perhaps be updated later.
- Right now the workflow is run on any push. One could limit this to only run on e.g. PRs towards master or similar.