### PR TITLE
unclassified-gz-bug

### DIFF
--- a/emu
+++ b/emu
@@ -32,6 +32,53 @@ RANKS_PRINTOUT = ['tax_id'] + TAXONOMY_RANKS + ['subspecies', 'species subgroup'
 RANKS_ORDER = ['tax_id'] + TAXONOMY_RANKS[:6] + TAXONOMY_RANKS[7:]
 
 
+def open_maybe_gzip(path, mode="rt"):
+    """Open plain text or gzipped files transparently (returns text handle)."""
+    if str(path).endswith((".gz", ".gzip")):
+        if "b" in mode:
+            mode = mode.replace("b", "")
+        return gzip.open(path, mode)
+    return open(path, mode, encoding="utf-8")
+
+
+def ids_match(rec_id, rec_name, keep_ids):
+    """Return True if record ID or name matches any ID in keep_ids."""
+    rid = rec_id.split()[0]
+    rname = rec_name.split()[0] if rec_name else ""
+    # Direct matches
+    if rid in keep_ids or rname in keep_ids:
+        return True
+    # Handle paired-end read suffixes (/1, /2)
+    if rid.endswith(("/1", "/2")) and rid[:-2] in keep_ids:
+        return True
+    return False
+
+def detect_seq_type(path):
+    """
+    Detect FASTA vs FASTQ from filename suffixes; if unclear, peek at content.
+    Returns 'fasta' or 'fastq'.
+    """
+    p = Path(path)
+    suffixes = set(s.lower() for s in p.suffixes)  # e.g., ['.fastq', '.gz']
+    # Extension-based guesses
+    if {".fastq", ".fq"} & suffixes:
+        return "fastq"
+    if {".fasta", ".fa", ".fna", ".fas"} & suffixes:
+        return "fasta"
+    # Fallback: content sniffing
+    with open_maybe_gzip(path, "rt") as fh:
+        for line in fh:
+            s = line.strip()
+            if not s:
+                continue
+            if s.startswith(">"):
+                return "fasta"
+            if s.startswith("@"):
+                return "fastq"
+            # If first non-empty line is neither, keep scanning a bit more
+        raise ValueError(f"Could not detect file type (FASTA/FASTQ) from: {path}")
+
+
 def validate_input(path):
     """Validate input file is either: fasta, fastq, or sam alignement file.
 
@@ -79,28 +126,21 @@ def get_align_len(alignment):
 
 
 def output_sequences(in_path, seq_output_path, input_type, keep_ids):
-    """ Output specified list of sequences from input_file based on sequence id
+    """Output specified sequences from input_file based on sequence id.
 
-        in_path (str): path to input fasta or fastq
-        seq_output_path (str): output path for fasta/q of unclassified sequences
-        input_type (str): fasta or fastq
-        keep_ids (set): set of seuqence id strings
+    Args:
+        in_path (str): path to input fasta or fastq (optionally .gz)
+        seq_output_path (str): output path prefix (extension added automatically)
+        input_type (str): 'fasta' or 'fastq'
+        keep_ids (set[str]): set of sequence id strings to keep
     """
-    # Filter and write only the sequences with matching read IDs
-    # Open the input file based on its extension
-    if in_path.endswith(".gz"):
-        open_func = lambda p: gzip.open(p, "rt", encoding="utf-8")  # Open as text stream
-    else:
-        open_func = lambda p: open(p, "r", encoding="utf-8")  # Standard text mode open
+    ext_map = {"fasta": ".fasta", "fastq": ".fastq"}
+    out_path = f"{seq_output_path}{ext_map.get(input_type, '.fasta')}"
 
-        # Open input and output files
-    with open_func(in_path) as in_file, \
-            open("{}.{}".format(seq_output_path, input_type), "w", encoding="utf-8") as out_seq_file:
-        # Parse the FASTA/FASTQ file and filter by read IDs
-        filtered_sequences = (seq for seq in SeqIO.parse(in_file, input_type) if seq.id in keep_ids)
-
-        # Write the filtered sequences to the output file
-        SeqIO.write(filtered_sequences, out_seq_file, input_type)
+    with open_maybe_gzip(in_path, "rt") as in_file, open(out_path, "w", encoding="utf-8") as out_seq_file:
+        for rec in SeqIO.parse(in_file, input_type):
+            if ids_match(rec.id, getattr(rec, "name", ""), keep_ids):
+                SeqIO.write(rec, out_seq_file, input_type)
 
 
 def get_cigar_op_log_probabilities(sam_path):
@@ -697,7 +737,7 @@ def combine_outputs(dir_path, rank, split_files=False, count_table=False):
     return df_combined_full
 
 if __name__ == "__main__":
-    __version__ = "3.5.2"
+    __version__ = "3.5.3"
     parser = argparse.ArgumentParser()
     parser.add_argument('--version', '-v', action='version', version='%(prog)s v' + __version__)
     subparsers = parser.add_subparsers(dest="subparser_name", help='sub-commands')
@@ -841,14 +881,11 @@ if __name__ == "__main__":
 
         # gather input sequences that are unmapped according to minimap2
         if args.output_unclassified:
-            ext = os.path.splitext(args.input_file[0])[-1]
-            INPUT_FILETYPE = "fasta"
-            if ext in [".fastq", ".fq"]:
-                INPUT_FILETYPE = "fastq"
-            output_sequences(args.input_file[0], "{}_unmapped".format(out_file), INPUT_FILETYPE,
+            input_filetype = detect_seq_type(args.input_file[0])
+            output_sequences(args.input_file[0], "{}_unmapped".format(out_file), input_filetype,
                                                 set_unmapped)
             output_sequences(args.input_file[0], "{}_unclassified_mapped".format(out_file),
-                             INPUT_FILETYPE, mapped_unclassified)
+                             input_filetype, mapped_unclassified)
 
         # clean up extra file
         if not args.keep_files:


### PR DESCRIPTION
In response to issue #88 
--Output-unclassified previously could not handle gzip compressed fastq files. Cases have been updated to handle these file types.