### PR TITLE
Fix #90: Allow a small tolerance when checking for a decreasing log-likelihood

### DIFF
--- a/emu
+++ b/emu
@@ -738,7 +738,7 @@ def combine_outputs(dir_path, rank, split_files=False, count_table=False):
     return df_combined_full
 
 if __name__ == "__main__":
-    __version__ = "3.5.3"
+    __version__ = "3.5.4"
     parser = argparse.ArgumentParser()
     parser.add_argument('--version', '-v', action='version', version='%(prog)s v' + __version__)
     subparsers = parser.add_subparsers(dest="subparser_name", help='sub-commands')


### PR DESCRIPTION
This fixes #90 by allowing a small tolerance when checking for the decreasing log_likelihood.

(I have sent a test data file that triggers the error, via mail).

The fix adds a small tolerance to allow small remainders after the diffing of floating point numbers, as it is a common issue that small such can remain.

I set it to `1e-9` based on the fact that this is what is used for the relative tolerance in the `math.is_close()` function in python (see [docs here](https://docs.python.org/3/library/math.html#math.isclose)).

## Manual testing

### Before applying the fix

```bash
$ git branch
  90-fix-decreasing-log-likelihood
* master
$ ./emu abundance --type map-ont --db emu_database --threads 12 --output-dir output ../emu-issue90-anon.fq.gz 
[M::mm_idx_gen::0.950*1.25] collected minimizers
[M::mm_idx_gen::1.056*2.16] sorted minimizers
[M::main::1.061*2.16] loaded/built the index for 49243 target sequence(s)
[M::mm_mapopt_update::1.071*2.15] mid_occ = 14113
[M::mm_idx_stat] kmer size: 15; skip: 10; is_hpc: 0; #seq: 49243
[M::mm_idx_stat::1.078*2.14] distinct minimizers: 462637 (45.14% are singletons); average occurrences: 28.757; average spacing: 5.572; total length: 74133434
[M::worker_pipeline::14.337*10.18] mapped 501 sequences
[M::main] Version: 2.24-r1122
[M::main] CMD: minimap2 -ax map-ont -t 12 -N 50 -p .9 -K 500000000 -o output/emu-issue90-anon.fq_emu_alignments.sam emu_database/species_taxid.fasta ../emu-issue90-anon.fq.gz
[M::main] Real time: 14.355 sec; CPU: 145.991 sec; Peak RSS: 0.916 GB
Unmapped read count: 7
Mapped read count: 494
Traceback (most recent call last):
  File "/home/shl/proj/25/66-emu-bug/emu/./emu", line 859, in <module>
    f_full, f_set_thresh, read_dist = expectation_maximization_iterations(log_prob_rgs,
                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
                                                               db_species_tids,
                                                               ^^^^^^^^^^^^^^^^
                                                               .01, args.min_abundance)
                                                               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/shl/proj/25/66-emu-bug/emu/./emu", line 365, in expectation_maximization_iterations
    raise ValueError("total_log_likelihood decreased from prior iteration")
ValueError: total_log_likelihood decreased from prior iteration
```

### After applying the fix

```bash
$ git checkout 90-fix-decreasing-log-likelihood 
Switched to branch '90-fix-decreasing-log-likelihood'
Your branch is up to date with 'origin/90-fix-decreasing-log-likelihood'.
$ ./emu abundance --type map-ont --db emu_database --threads 12 --output-dir output ../emu-issue90-anon.fq.gz 
[M::mm_idx_gen::0.979*1.24] collected minimizers
[M::mm_idx_gen::1.093*2.18] sorted minimizers
[M::main::1.097*2.18] loaded/built the index for 49243 target sequence(s)
[M::mm_mapopt_update::1.108*2.17] mid_occ = 14113
[M::mm_idx_stat] kmer size: 15; skip: 10; is_hpc: 0; #seq: 49243
[M::mm_idx_stat::1.116*2.16] distinct minimizers: 462637 (45.14% are singletons); average occurrences: 28.757; average spacing: 5.572; total length: 74133434
[M::worker_pipeline::15.407*9.86] mapped 501 sequences
[M::main] Version: 2.24-r1122
[M::main] CMD: minimap2 -ax map-ont -t 12 -N 50 -p .9 -K 500000000 -o output/emu-issue90-anon.fq_emu_alignments.sam emu_database/species_taxid.fasta ../emu-issue90-anon.fq.gz
[M::main] Real time: 15.426 sec; CPU: 152.005 sec; Peak RSS: 0.908 GB
Unmapped read count: 7
Mapped read count: 494
Number of EM iterations: 3
Unclassified mapped read count: 0
```