### PR TITLE
Fix #94: Fix and clean up CI with supported Ubuntu version and more

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,41 +1,31 @@
-name: Python Package using Conda
+name: Run tests
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build-linux:
-    runs-on: ubuntu-20.04
-    strategy:
-      max-parallel: 5
+    runs-on: ubuntu-24.04
     defaults:
       run:
         shell: bash -l {0}
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.6.15
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.6.15'
-    - name: Create conda/mamba environment using micromamba
-      uses: mamba-org/setup-micromamba@v1
+    - uses: mamba-org/setup-micromamba@v2
       with:
         environment-file: environment.yml
-        cache-downloads: true
-    - name: Add micromamba to system path                                                                                                                                                                                                                         
-      run: |                                                                                                                                                                                                                                                 
-        # $CONDA is an environment variable pointing to the root of the miniconda directory                                                                                                                                                                  
-        echo $CONDA/bin >> $GITHUB_PATH
-    - name: Set EMU_DATABASE env variable
-      run: echo "EMU_DATABASE_DIR=./emu_database" >> $GITHUB_ENV
+        init-shell: >-
+          bash
+        cache-environment: true
+        post-cleanup: 'all'
     - name: Lint with flake8
       run: |
         micromamba install flake8
         # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        flake8 emu tests --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
+        flake8 emu tests --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Run Python tests with pytest
       run: |
         micromamba install pytest
         pytest


### PR DESCRIPTION
This PR fixes #94 by fixing these things:

- Updates the Ubuntu version to a supported (and long term support (LTS) one): 24.04

It also:

- Updates the micromamba action to v2, using the best practice way of installing it.
- Cleans up the flake8 command to only run on the emu library and tests folder.
- Restricts the CI to run only on pull requests, not every push.