### PR TITLE
Make sure CI is run on push to master too

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,6 +1,12 @@
 name: Run tests
 
-on: [pull_request]
+on:
+  pull_request:
+    branches:
+      - "**"
+  push:
+    branches:
+      - master
 
 jobs:
   build-linux:


### PR DESCRIPTION
I saw the status badge in the readme was still not updated although tests in the PR ran fine.

This update should fix this, by running CI also on pushes to master.